### PR TITLE
Allow decimal numbers

### DIFF
--- a/src/markup.js
+++ b/src/markup.js
@@ -90,10 +90,15 @@ const markup = {
         return `<input type="${field.type}" value="${field.value}" name="${field.name}">`;
 
       default:
+        let extraAttributes = '';
+        if (field.type.toLowerCase() === 'number') {
+          extraAttributes = 'step="any"';
+        }
+
         return `
           <div class="form-field">
             <label>${field.name}</label>
-            <input type="${field.type}" value="${field.value}" name="${field.name}">
+            <input type="${field.type}" value="${field.value}" name="${field.name}" ${extraAttributes}>
           </div>
           `;
     }

--- a/src/markup.js
+++ b/src/markup.js
@@ -85,16 +85,19 @@ const markup = {
   },
 
   fieldForm(field) {
-    switch (field.type) {
+    switch (field.type.toLowerCase()) {
       case 'hidden':
         return `<input type="${field.type}" value="${field.value}" name="${field.name}">`;
 
-      default:
-        let extraAttributes = '';
-        if (field.type.toLowerCase() === 'number') {
-          extraAttributes = 'step="any"';
-        }
+      case 'number':
+        return `
+          <div class="form-field">
+            <label>${field.name}</label>
+            <input type="${field.type}" value="${field.value}" name="${field.name}" step="any">
+          </div>
+          `;
 
+      default:
         return `
           <div class="form-field">
             <label>${field.name}</label>

--- a/src/markup.js
+++ b/src/markup.js
@@ -101,7 +101,7 @@ const markup = {
         return `
           <div class="form-field">
             <label>${field.name}</label>
-            <input type="${field.type}" value="${field.value}" name="${field.name}" ${extraAttributes}>
+            <input type="${field.type}" value="${field.value}" name="${field.name}">
           </div>
           `;
     }


### PR DESCRIPTION
W3C states that the `input` element with type `number` will allow any valid number that can be selected based on what the `step` attribute it set to.
By default `step` is set to 1. `step="any"` allows the number to be any decimal.