### PR TITLE
Support for radio inputs with array of values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwreck",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "description": "Heed the Sirens' call",
   "main": "index.html",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ ship.on('fetch', () => {
 
 ship.on('update', e => {
   const { entity, href } = e.detail;
-  const self = entity && entity.link('self');
+  const self = entity && entity.link({ rel: 'self' });
   let uri = self && self.href || href;
   if (uri) {
     uri = uri.replace(ship.baseUri, '');

--- a/src/markup.js
+++ b/src/markup.js
@@ -42,17 +42,17 @@ const markup = {
         <div class="body tabbed">
           <div class="entity-links">
             <label>links:</label>
-            <ul>${entity.links.map(l => `<li>${markup.linkAnchor(l)}</li>`).join('\n')}</ul>
+            <ul>${entity.links().map(l => `<li>${markup.linkAnchor(l)}</li>`).join('\n')}</ul>
           </div>
           <div class="tabs">
             <a name="entity-properties">properties</a>
-            ${entity.actions.length ? '<a name="entity-actions">actions</a>' : '' }
+            ${entity.actions().length ? '<a name="entity-actions">actions</a>' : '' }
           </div>
           <div class="tab-content entity-properties entity-raw">
             ${markup.code(entity.properties)}
           </div>
           <div class="tab-content entity-actions">
-            ${entity.actions.map(markup.actionForm).join('\n')}
+            ${entity.actions().map(markup.actionForm).join('\n')}
           </div>
         </div>
       </div>
@@ -142,17 +142,32 @@ const markup = {
         <div class="form-field">
           <label>
             ${field.title || field.name}
-            <input type="${field.type}" name="${field.name}" value="${field.value}"${ field.value ? ' checked' : '' } />
+            <input type="${field.type}" name="${field.name}" value="${field.value}" ${ field.checked ? 'checked' : '' } />
           </label>
         </div>
         `;
 
     case 'radio':
+      if (field.value instanceof Array) {
+        return `
+          <div class="form-field">
+            <h4>${field.title || field.name}</h4>
+            ${field.value.map((option) => `
+            <div>
+              <label>
+                <input type="${field.type}" name="${field.name}" value="${option.value}" ${ option.checked ? 'checked' : '' } />
+                ${option.title}
+              </label>
+            </div>
+            `).join('')}
+          </div>
+        `;
+      }
       return `
         <div class="form-field">
           <label>
+            <input type="${field.type}" name="${field.name}" value="${field.value}" ${ field.checked ? 'checked' : '' } />
             ${field.title || field.name}
-            <input type="${field.type}" name="${field.name}" value="${field.value}"${ field.checked ? ' checked' : '' } />
           </label>
         </div>
         `;
@@ -223,13 +238,13 @@ const markup = {
 
   // Display the [self] href in a nice clickable manner
   currentPath(entity) {
-    const link = entity && entity.link('self');
+    const link = entity && entity.link({ rel: 'self' });
     return link ? markup.uriCrumbs(link.href) : '';
   },
 
   // Display the query parameters - if present - of [self] href
   queryParams(entity) {
-    const link = entity.link('self');
+    const link = entity.link({ rel: 'self' });
     return link ? markup.uriParams(link.href) : '';
   },
 
@@ -244,9 +259,9 @@ const markup = {
             [ ${entity.class.join(', ')} ]
           </div>
 
-          <div class="entity-links" ${entity.links.length === 0 ? 'hidden': ''}>
+          <div class="entity-links" ${entity.links().length === 0 ? 'hidden': ''}>
             <h2>Links</h2>
-            ${entity.links.map(l => `<div>${markup.linkAnchor(l)}</div>`).join('\n')}
+            ${entity.links().map(l => `<div>${markup.linkAnchor(l)}</div>`).join('\n')}
           </div>
 
           <div class="entity-properties" ${Object.keys(entity.properties).length === 0 ? 'hidden': ''}>
@@ -254,13 +269,13 @@ const markup = {
             <table><tbody>${markup.propertyRows(entity)}</tbody></table>
           </div>
 
-          <div class="entity-actions" ${entity.actions.length === 0 ? 'hidden': ''}>
+          <div class="entity-actions" ${entity.actions().length === 0 ? 'hidden': ''}>
             <h2>Actions</h2>
-            ${entity.actions.map(markup.card).join('\n')}
+            ${entity.actions().map(markup.card).join('\n')}
           </div>
 
         </div>
-        <div class="flex-2" ${entity.entities.length === 0 ? 'hidden': ''}>
+        <div class="flex-2" ${entity.entities().length === 0 ? 'hidden': ''}>
 
           <!-- Sub-Entities -->
           <div class="entity-entities">

--- a/src/shipwreck.js
+++ b/src/shipwreck.js
@@ -49,13 +49,18 @@ export class Shipwreck extends EventEmitter {
 
   async formSubmit(form) {
     const fields = [];
-    let method;
     for (const { name, value, type, checked } of form.elements) {
       if (name === '_method') {
         method = value;
         continue;
       }
-      name && fields.push({ name, value: type === 'checkbox' ? checked : value });
+      if (type === 'radio' && !checked) {
+        continue;
+      }
+      if (type === 'checkbox' && !checked) {
+        continue;
+      }
+      name && fields.push({ name, value });
     }
     const action = {
       name: form.name,
@@ -217,7 +222,7 @@ export class Shipwreck extends EventEmitter {
 
     // Sub-Entities
     const parent = target.querySelector('.entity-entities');
-    entity.entities.forEach(e => {
+    entity._entities.forEach(e => {
       const card = _html(markup.card(e));
       parent.appendChild(card);
       // toggle body visibility when head is clicked

--- a/src/shipwreck.js
+++ b/src/shipwreck.js
@@ -49,6 +49,7 @@ export class Shipwreck extends EventEmitter {
 
   async formSubmit(form) {
     const fields = [];
+    let method;
     for (const { name, value, type, checked } of form.elements) {
       if (name === '_method') {
         method = value;


### PR DESCRIPTION
Updated markup to support radio fields with an array of values as per: https://github.com/kevinswiber/siren/pull/69/files
```
fields: [
  { 
    type: 'radio', 
    name: 'thing_with_options',
    value: [
      { title: 'option 1', value: '1', checked: true },
      ...
    ],
  },
]
```
Updated links() And entities() helper methods to take an object in the form `{ rel, class }`, if a string is passed, it will search both rel and class.
