### PR TITLE
Link directly to resources when type is set

### DIFF
--- a/demo/box.js
+++ b/demo/box.js
@@ -29,7 +29,7 @@ export default {
       },
       links: [
         { rel: ['self'], href: 'http://api.example.com/users/1' },
-        { rel: ['http://example.com/rel/box-owner-website'], href: 'http://example.com', type: 'application/html' },
+        { rel: ['http://example.com/rel/box-owner-website'], href: 'http://example.com', type: 'application/html', title: 'Box owner\'s website' },
       ],
     },
   ],

--- a/demo/box.js
+++ b/demo/box.js
@@ -29,7 +29,7 @@ export default {
       },
       links: [
         { rel: ['self'], href: 'http://api.example.com/users/1' },
-        { rel: ['http://example.com/rel/box-owner-website'], href: 'http://example.com', type: 'application/html', title: 'Box owner\'s website' },
+        { rel: ['http://example.com/rel/box-owner-website'], href: 'http://example.com', type: 'text/html', title: 'Box owner\'s website' },
       ],
     },
   ],

--- a/demo/box.js
+++ b/demo/box.js
@@ -29,6 +29,7 @@ export default {
       },
       links: [
         { rel: ['self'], href: 'http://api.example.com/users/1' },
+        { rel: ['http://example.com/rel/box-owner-website'], href: 'http://example.com', type: 'application/html' },
       ],
     },
   ],

--- a/src/markup.js
+++ b/src/markup.js
@@ -65,7 +65,10 @@ const markup = {
   // Links
 
   linkAnchor(link) {
-    const rels = link.rel.map((rel) => `<a href="${link.href}">${rel}</a>`).join(', ');
+    const shouldLinkDirectly = (link.type !== null && link.type !== '' && link.type !== 'application/vnd.siren+json');
+    const linkClass = shouldLinkDirectly ? 'class="direct-link"' : '';
+
+    const rels = link.rel.map((rel) => `<a ${linkClass} href="${link.href}">${rel}</a>`).join(', ');
     return `[ ${rels} ] <a href="${link.href}">${link.title}</a>`;
   },
 

--- a/src/markup.js
+++ b/src/markup.js
@@ -65,11 +65,14 @@ const markup = {
   // Links
 
   linkAnchor(link) {
-    const shouldLinkDirectly = (link.type !== null && link.type !== '' && link.type !== 'application/vnd.siren+json');
-    const linkClass = shouldLinkDirectly ? 'class="direct-link"' : '';
-
-    const rels = link.rel.map((rel) => `<a ${linkClass} href="${link.href}">${rel}</a>`).join(', ');
-    return `[ ${rels} ] <a href="${link.href}">${link.title}</a>`;
+    const notSiren = link.type && link.type.search(/application\/(vnd.siren\+)?json/) === -1;
+    const external = notSiren ? 'rel="external"' : '';
+    const rels = link.rel.map((rel) => `<a href="${link.href}" ${external}>${rel}</a>`).join(', ');
+    const parts = [`[ ${rels} ]`];
+    if (link.title) {
+      parts.push(`<a href="${link.href}" ${external}>${link.title}</a>`);
+    }
+    return parts.join(' ');
   },
 
   linkCard(link) {

--- a/src/shipwreck.js
+++ b/src/shipwreck.js
@@ -166,7 +166,7 @@ export class Shipwreck extends EventEmitter {
   async watchLinks() {
     const { target } = this;
     // Links (do this after sub entities are added)
-    target.querySelectorAll('.current-path a, .current-path-params a, #content-entity a')
+    target.querySelectorAll('.current-path a, .current-path-params a, #content-entity a:not(.direct-link)')
       .forEach((a) => a.addEventListener('click', (e) => {
         const { href } = e.target;
         if (!href) {

--- a/src/shipwreck.js
+++ b/src/shipwreck.js
@@ -168,12 +168,12 @@ export class Shipwreck extends EventEmitter {
     // Links (do this after sub entities are added)
     target.querySelectorAll('.current-path a, .current-path-params a, #content-entity a:not(.direct-link)')
       .forEach((a) => a.addEventListener('click', (e) => {
-        const { href } = e.target;
-        if (!href) {
+        const anchor = e.target;
+        if (!anchor || anchor.target || anchor.getAttribute('rel') === 'external' || !anchor.href) {
           return;
         }
         e.preventDefault();
-        this.fetch(href);
+        this.fetch(anchor.href);
       }));
   }
 

--- a/style/main.css
+++ b/style/main.css
@@ -326,3 +326,8 @@ select {
 .raw-response .content {
   white-space: pre-wrap;
 }
+
+/* entity links */
+.entity-links a.direct-link::after {
+   content: ' \1f517';
+}

--- a/style/main.css
+++ b/style/main.css
@@ -328,6 +328,6 @@ select {
 }
 
 /* entity links */
-.entity-links a.direct-link::after {
+.entity-links a[rel~="external"]::after {
    content: ' \1f517';
 }


### PR DESCRIPTION
When a link has a type explicitly set that is not `application/vnd.siren+json`, Shipwreck won't be able to parse the result. Instead of loading the resource in Shipwreck, link directly in the browser to the linked resource and let the browser handle it.

![Screenshot from 2020-04-16 16-24-21](https://user-images.githubusercontent.com/1207467/79598714-69748780-80b2-11ea-8eb0-9da903bc1ea9.png)
