### PR TITLE
send tokens to subdomains on same authorized domain

### DIFF
--- a/src/shipwreck.js
+++ b/src/shipwreck.js
@@ -75,7 +75,9 @@ export class Shipwreck extends EventEmitter {
     };
     this._raise('fetch', {});
     try {
-      const token = action.href.startsWith(this._baseUri) ? this._token : undefined;
+      const actionUrl = new URL(action.href);
+      const baseUrl = new URL(this._baseUri);
+      const token = actionUrl.hostname.endsWith(baseUrl.hostname) ? this._token : undefined;
       const { entity } = await this._store.submit({ action, token });
       if (entity) {
         this.entity = entity;


### PR DESCRIPTION
Sending tokens to any domains is a bad choice, but sending tokens to sub-domains of the same base seems pretty okay

Change sends tokens to domains that are subdomains

`https://api.example.com` will continue to work, but adds support for

`https://cats.api.example.com`,  and `https://furry.cats.api.example.com` and so on